### PR TITLE
Add top pagination controls

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,28 +1,71 @@
+"use client";
+
 import PokemonsComp from "@/components/pokemonsComp";
 import PokeNavBar from "@/components/pokeNavBarComp";
-
+import Pokemon from "@/model/pokemon";
+import PokemonCard from "@/model/pokemonCard";
+import { useEffect, useState } from "react";
+import { Button, Container } from "react-bootstrap";
 
 export default function Home() {
- const testData = [
-   {
-     pokemonNumber: 1,
-     pokemonName:"poke1",
-     pokemonType:["Water"],
-     mainImage: "https://raw.githubusercontent.com/HybridShivam/Pokemon/master/assets/images/001.png"
-   },
-   {
-     pokemonNumber: 2,
-     pokemonName:"poke2",
-     pokemonType:["Fire"],     
-     mainImage: "https://raw.githubusercontent.com/HybridShivam/Pokemon/master/assets/images/002.png"
-   }
- ];
+  const [pokemons, setPokemons] = useState<PokemonCard[]>([]);
+  const [page, setPage] = useState(1);
+  const [searchQuery, setSearchQuery] = useState("");
+  const pageSize = 50;
 
+  useEffect(() => {
+    const fetchData = async () => {
+      const resp = await fetch("/pokemons.json");
+      const data: Pokemon[] = await resp.json();
+      const pokemonCards: PokemonCard[] = data
+        .map((p) => ({
+          pokemonNumber: p.pokemonNumber,
+          pokemonName: p.pokemonName,
+          pokemonType: p.pokemonType,
+          mainImage: p.mainImage,
+        }))
+        .sort((a, b) => a.pokemonNumber - b.pokemonNumber);
+      setPokemons(pokemonCards);
+    };
 
- return (
-   <>
-     <PokeNavBar></PokeNavBar>
-     <PokemonsComp pokemons={testData}></PokemonsComp>
-   </>
- );
+    fetchData().catch((err) => console.error(err));
+  }, []);
+
+  useEffect(() => {
+    setPage(1);
+  }, [searchQuery]);
+
+  const filteredPokemons = pokemons.filter((p) =>
+    p.pokemonName.toLowerCase().includes(searchQuery.toLowerCase())
+  );
+  const totalPages = Math.ceil(filteredPokemons.length / pageSize);
+  const startIndex = (page - 1) * pageSize;
+  const currentPokemons = filteredPokemons.slice(
+    startIndex,
+    startIndex + pageSize
+  );
+
+  const handlePrev = () => setPage((p) => Math.max(p - 1, 1));
+  const handleNext = () => setPage((p) => Math.min(p + 1, totalPages));
+
+  return (
+    <>
+      <PokeNavBar searchQuery={searchQuery} setSearchQuery={setSearchQuery} />
+      <PokemonsComp
+        pokemons={currentPokemons}
+        page={page}
+        totalPages={totalPages}
+        onPrev={handlePrev}
+        onNext={handleNext}
+      />
+      <Container className="d-flex justify-content-center pb-4">
+        <Button onClick={handlePrev} disabled={page === 1} className="me-2">
+          Previous
+        </Button>
+        <Button onClick={handleNext} disabled={page === totalPages}>
+          Next
+        </Button>
+      </Container>
+    </>
+  );
 }

--- a/src/app/pokemon/[pokemon_id]/page.tsx
+++ b/src/app/pokemon/[pokemon_id]/page.tsx
@@ -4,7 +4,6 @@
 import Pokemon from '@/model/pokemon';
 import { useEffect, useState } from 'react';
 import { Row, Col, Container, Image } from 'react-bootstrap';
-import React from "react";
 
 
 
@@ -21,45 +20,41 @@ type Params = {
 // In our case http://localhost:3000/pokemon/2 is the URL.
 // Where the 2 is the [pokemon_id] and passed as a parameter.
 export default function PokemonPage({ params }: Params) {
-    const {pokemon_id} = React.use(params);
-   //pokemon - A constant state variable which stores the pokemon information and retains the data between renders.
-   //setPokemon - A state setter function to update the variable and trigger React to render the component again.
-   const [pokemon, setPokemon] = useState<Pokemon>();
+  const { pokemon_id } = params;
+  // pokemon - A state variable that stores the pokemon information.
+  const [pokemon, setPokemon] = useState<Pokemon>();
 
 
-   useEffect(() => {
-       const fetchData = async () => {
-           const resp = await fetch('/pokemons.json');
-           // Creating a Map out of the raw json
-           const pokemons: Map<string, Pokemon> = new Map(Object.entries(await resp.json()));
-           const currentPokemon = pokemons.get(pokemon_id);
-           setPokemon(currentPokemon);
-           console.log(currentPokemon);
-       };
+  useEffect(() => {
+    const fetchData = async () => {
+      const resp = await fetch('/pokemons.json');
+      const data: Pokemon[] = await resp.json();
+      const currentPokemon = data.find(
+        (p) => p.pokemonNumber === Number(pokemon_id)
+      );
+      setPokemon(currentPokemon);
+    };
+
+    fetchData().catch((error) => {
+      console.error(error);
+    });
+  }, [pokemon_id]);
 
 
-       fetchData()
-           // Making sure to log errors on the console
-           .catch(error => {
-               console.error(error);
-           });
-   }, []);
-
-
-   return (
-       <Container>
-           <Row className="justify-content-md-center">
-               <Col md="auto"><h1>{pokemon?.pokemonName}</h1></Col>
-           </Row>
-           <Row>
-               <Col >
-                   <Image src={pokemon?.mainImage} thumbnail />
-               </Col>
-               <Col>
-                   Pokémon Properties
-               </Col>
-           </Row>
-       </Container>
-   );
+  return (
+    <Container>
+      <Row className="justify-content-md-center">
+        <Col md="auto">
+          <h1>{pokemon?.pokemonName}</h1>
+        </Col>
+      </Row>
+      <Row>
+        <Col>
+          <Image src={pokemon?.mainImage} thumbnail />
+        </Col>
+        <Col>Pokémon Properties</Col>
+      </Row>
+    </Container>
+  );
 }
 

--- a/src/components/pokeNavBarComp.tsx
+++ b/src/components/pokeNavBarComp.tsx
@@ -3,20 +3,37 @@
 
 import Nav from 'react-bootstrap/Nav';
 import Navbar from 'react-bootstrap/Navbar';
-import { Container } from 'react-bootstrap';
+import { Container, Form } from 'react-bootstrap';
+
+interface PokeNavBarCompProps {
+  searchQuery: string;
+  setSearchQuery: (value: string) => void;
+}
 
 
-export default function PokeNavBarComp() {
-   return (
-       <>
-           <Navbar bg="dark" data-bs-theme="dark">
-               <Container>
-                   <Navbar.Brand href='/'>Pokedex</Navbar.Brand>
-                   <Nav className="me-auto">
-                       <Nav.Link href='/'>Home</Nav.Link>
-                   </Nav>
-               </Container>
-           </Navbar>
-       </>
-   );
+export default function PokeNavBarComp({ searchQuery, setSearchQuery }: PokeNavBarCompProps) {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchQuery(e.target.value);
+  };
+
+  return (
+    <>
+      <Navbar bg="dark" data-bs-theme="dark">
+        <Container>
+          <Navbar.Brand href='/'>Pokedex</Navbar.Brand>
+          <Nav className="me-auto">
+            <Nav.Link href='/'>Home</Nav.Link>
+          </Nav>
+          <Form className="d-flex">
+            <Form.Control
+              type="search"
+              placeholder="Search"
+              value={searchQuery}
+              onChange={handleChange}
+            />
+          </Form>
+        </Container>
+      </Navbar>
+    </>
+  );
 }

--- a/src/components/pokemonsComp.tsx
+++ b/src/components/pokemonsComp.tsx
@@ -3,27 +3,48 @@
 
 import Container from "react-bootstrap/Container";
 import PokemonCard from "@/model/pokemonCard";
-import { Row, Col } from "react-bootstrap";
+import { Row, Col, Button } from "react-bootstrap";
 import PokemonCardComp from "@/components/pokemonCardComp";
 
 
 
 
 interface PokemonsCompProps {
-   pokemons: PokemonCard[];
+  pokemons: PokemonCard[];
+  page: number;
+  totalPages: number;
+  onPrev: () => void;
+  onNext: () => void;
 }
 
 
-export default function PokemonsComp(props: PokemonsCompProps) {
-   return (
-       <Container className="pt-4 pb-4">
-           <Row xs={1} md={3} lg={5} className="g-4">
-               {props.pokemons.map((pokemon) => (
-                   <Col key={pokemon.pokemonNumber}>
-                       <PokemonCardComp pokemon={pokemon}/>
-                   </Col>
-               ))}
-           </Row>
-       </Container>
-   );
+export default function PokemonsComp({
+  pokemons,
+  page,
+  totalPages,
+  onPrev,
+  onNext,
+}: PokemonsCompProps) {
+  return (
+    <>
+      <Container className="d-flex justify-content-center pt-4">
+        <Button onClick={onPrev} disabled={page === 1} className="me-2">
+          Previous
+        </Button>
+        <div className="align-self-center">{`Page ${page}/${totalPages}`}</div>
+        <Button onClick={onNext} disabled={page === totalPages} className="ms-2">
+          Next
+        </Button>
+      </Container>
+      <Container className="pt-4 pb-4">
+        <Row xs={1} md={3} lg={5} className="g-4">
+          {pokemons.map((pokemon) => (
+            <Col key={pokemon.pokemonNumber}>
+              <PokemonCardComp pokemon={pokemon} />
+            </Col>
+          ))}
+        </Row>
+      </Container>
+    </>
+  );
 }


### PR DESCRIPTION
## Summary
- show page control at top of Pokémon grid
- pass pagination info to `PokemonsComp`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c4bd074b88322bad27a80678f08ef