### PR TITLE
Add pokemon type color mappings

### DIFF
--- a/src/app/pokemon/[pokemon_id]/page.tsx
+++ b/src/app/pokemon/[pokemon_id]/page.tsx
@@ -3,7 +3,10 @@
 'use client'
 import Pokemon from '@/model/pokemon';
 import { useEffect, useState } from 'react';
-import { Row, Col, Container, Image } from 'react-bootstrap';
+import { Row, Col, Container, Image, ProgressBar } from 'react-bootstrap';
+import PokeNavBarNoSearchComp from '@/components/pokeNavBarNoSearchComp';
+import PokemonTypeBadgeComp from '@/components/pokemonTypeBadgeComp';
+import TYPE_COLORS from '@/utils/typeColors';
 
 
 
@@ -42,19 +45,82 @@ export default function PokemonPage({ params }: Params) {
 
 
   return (
-    <Container>
-      <Row className="justify-content-md-center">
-        <Col md="auto">
-          <h1>{pokemon?.pokemonName}</h1>
-        </Col>
-      </Row>
-      <Row>
-        <Col>
-          <Image src={pokemon?.mainImage} thumbnail />
-        </Col>
-        <Col>Pokémon Properties</Col>
-      </Row>
-    </Container>
+    <>
+      <PokeNavBarNoSearchComp />
+      <Container className="pt-4">
+        <Row className="justify-content-md-center mb-2">
+          <Col md="auto">
+            <h1>{pokemon?.pokemonName}</h1>
+          </Col>
+        </Row>
+        <Row className="justify-content-md-center mb-4">
+          <Col md="auto">
+            {pokemon?.pokemonType && (
+              <PokemonTypeBadgeComp pokemonTypes={pokemon.pokemonType} />
+            )}
+          </Col>
+        </Row>
+        <Row className="mb-4">
+          <Col md="4" className="text-center">
+            <Image src={pokemon?.mainImage} thumbnail />
+          </Col>
+          <Col>
+            <h4 className="mb-3">Stats</h4>
+            <div className="mb-2">
+              <div>Attack</div>
+              <ProgressBar
+                now={pokemon?.attack || 0}
+                max={150}
+                label={pokemon?.attack?.toString()}
+                style={{ backgroundColor: TYPE_COLORS[pokemon?.pokemonType?.[0] ?? ''] }}
+              />
+            </div>
+            <div className="mb-2">
+              <div>Defense</div>
+              <ProgressBar
+                now={pokemon?.defense || 0}
+                max={180}
+                label={pokemon?.defense?.toString()}
+                style={{ backgroundColor: TYPE_COLORS[pokemon?.pokemonType?.[0] ?? ''] }}
+              />
+            </div>
+            <div className="mb-2">
+              <div>HP</div>
+              <ProgressBar
+                now={pokemon?.healthPoints || 0}
+                max={250}
+                label={pokemon?.healthPoints?.toString()}
+                style={{ backgroundColor: TYPE_COLORS[pokemon?.pokemonType?.[0] ?? ''] }}
+              />
+            </div>
+            <div className="mb-2">
+              <div>Speed</div>
+              <ProgressBar
+                now={pokemon?.speed || 0}
+                max={150}
+                label={pokemon?.speed?.toString()}
+                style={{ backgroundColor: TYPE_COLORS[pokemon?.pokemonType?.[0] ?? ''] }}
+              />
+            </div>
+          </Col>
+        </Row>
+        {pokemon?.evolutionFamily?.length ? (
+          <Row>
+            <Col>
+              <h4 className="mb-2">Evolution</h4>
+              <div>
+                {pokemon.evolutionFamily.map((name, idx) => (
+                  <span key={name} className={name === pokemon.pokemonName ? 'bg-danger text-white p-1' : 'p-1'}>
+                    {name}
+                    {idx < pokemon.evolutionFamily.length - 1 && ' \u2192 '}
+                  </span>
+                ))}
+              </div>
+            </Col>
+          </Row>
+        ) : null}
+      </Container>
+    </>
   );
 }
 

--- a/src/components/pokeNavBarNoSearchComp.tsx
+++ b/src/components/pokeNavBarNoSearchComp.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import Nav from 'react-bootstrap/Nav';
+import Navbar from 'react-bootstrap/Navbar';
+import { Container } from 'react-bootstrap';
+
+export default function PokeNavBarNoSearchComp() {
+  return (
+    <Navbar bg="dark" data-bs-theme="dark">
+      <Container>
+        <Navbar.Brand href='/'>Pokedex</Navbar.Brand>
+        <Nav className="me-auto">
+          <Nav.Link href='/'>Home</Nav.Link>
+        </Nav>
+      </Container>
+    </Navbar>
+  );
+}

--- a/src/components/pokemonTypeBadgeComp.tsx
+++ b/src/components/pokemonTypeBadgeComp.tsx
@@ -2,6 +2,7 @@
 
 
 import { Badge } from "react-bootstrap";
+import TYPE_COLORS from "@/utils/typeColors";
 
 
 interface PokemonCardCompProps {
@@ -13,17 +14,16 @@ export default function PokemonTypeBadgeComp(props: PokemonCardCompProps) {
    return (
        <>
            {props.pokemonTypes?.map((pokemonType, index) => {
-               if (pokemonType === "Water") {
-                   return <Badge key={index} bg="primary">{pokemonType}</Badge>
-               } else if (pokemonType === "Fire") {
-                   return <Badge key={index} bg="danger">{pokemonType}</Badge>
-               } else if (pokemonType === "Grass") {
-                   return <Badge key={index} bg="success">{pokemonType}</Badge>
-               } else if (pokemonType === "Electric") {
-                   return <Badge key={index} bg="warning">{pokemonType}</Badge>
-               } else {
-                   return <Badge key={index} bg="secondary">{pokemonType}</Badge>
-               }
+               const color = TYPE_COLORS[pokemonType] || 'gray';
+               return (
+                   <Badge
+                       key={index}
+                       style={{ backgroundColor: color }}
+                       className="me-1 text-white"
+                   >
+                       {pokemonType}
+                   </Badge>
+               );
            })}
        </>
    );

--- a/src/utils/typeColors.ts
+++ b/src/utils/typeColors.ts
@@ -1,0 +1,22 @@
+const TYPE_COLORS: Record<string, string> = {
+  Fire: 'orange',
+  Water: '#0d6efd',
+  Grass: 'green',
+  Electric: '#f7d02c',
+  Poison: 'indigo',
+  Ice: '#007fff',
+  Normal: 'gray',
+  Fighting: 'brown',
+  Ground: 'sienna',
+  Rock: 'darkgray',
+  Psychic: 'purple',
+  Fairy: 'hotpink',
+  Bug: 'olive',
+  Dragon: 'teal',
+  Ghost: 'slateblue',
+  Dark: 'black',
+  Steel: 'silver',
+  Flying: 'skyblue',
+};
+
+export default TYPE_COLORS;


### PR DESCRIPTION
## Summary
- color-code pokemon types using a new TYPE_COLORS map
- show type badges on the detail page
- apply type colors to stat progress bars

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c5d58a7a88322a1a5ba01595f7c45