### PR TITLE
Show Pokémon evolution cards

### DIFF
--- a/src/app/pokemon/[pokemon_id]/page.tsx
+++ b/src/app/pokemon/[pokemon_id]/page.tsx
@@ -3,9 +3,10 @@
 'use client'
 import Pokemon from '@/model/pokemon';
 import { useEffect, useState } from 'react';
-import { Row, Col, Container, Image, ProgressBar } from 'react-bootstrap';
+import { Row, Col, Container, Image, ProgressBar, Card } from 'react-bootstrap';
 import PokeNavBarNoSearchComp from '@/components/pokeNavBarNoSearchComp';
 import PokemonTypeBadgeComp from '@/components/pokemonTypeBadgeComp';
+import PokemonEvolutionCardComp from '@/components/pokemonEvolutionCardComp';
 import TYPE_COLORS from '@/utils/typeColors';
 
 
@@ -26,12 +27,14 @@ export default function PokemonPage({ params }: Params) {
   const { pokemon_id } = params;
   // pokemon - A state variable that stores the pokemon information.
   const [pokemon, setPokemon] = useState<Pokemon>();
+  const [allPokemons, setAllPokemons] = useState<Pokemon[]>([]);
 
 
   useEffect(() => {
     const fetchData = async () => {
       const resp = await fetch('/pokemons.json');
       const data: Pokemon[] = await resp.json();
+      setAllPokemons(data);
       const currentPokemon = data.find(
         (p) => p.pokemonNumber === Number(pokemon_id)
       );
@@ -105,16 +108,20 @@ export default function PokemonPage({ params }: Params) {
           </Col>
         </Row>
         {pokemon?.evolutionFamily?.length ? (
-          <Row>
-            <Col>
+          <Row className="justify-content-center">
+            <Col md="auto" className="text-center">
               <h4 className="mb-2">Evolution</h4>
-              <div>
-                {pokemon.evolutionFamily.map((name, idx) => (
-                  <span key={name} className={name === pokemon.pokemonName ? 'bg-danger text-white p-1' : 'p-1'}>
-                    {name}
-                    {idx < pokemon.evolutionFamily.length - 1 && ' \u2192 '}
-                  </span>
-                ))}
+              <div className="d-flex justify-content-center flex-wrap gap-3">
+                {pokemon.evolutionFamily.map((name) => {
+                  const evo = allPokemons.find((p) => p.pokemonName === name);
+                  return evo ? (
+                    <PokemonEvolutionCardComp key={name} pokemon={evo} />
+                  ) : (
+                    <Card key={name} className="align-items-center p-2">
+                      <Card.Text>{name}</Card.Text>
+                    </Card>
+                  );
+                })}
               </div>
             </Col>
           </Row>

--- a/src/components/pokemonEvolutionCardComp.tsx
+++ b/src/components/pokemonEvolutionCardComp.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import Pokemon from "@/model/pokemon";
+import { Card, Image } from "react-bootstrap";
+
+interface PokemonEvolutionCardCompProps {
+  pokemon: Pokemon;
+}
+
+export default function PokemonEvolutionCardComp({ pokemon }: PokemonEvolutionCardCompProps) {
+  const pokemonUrl = `/pokemon/${pokemon.pokemonNumber}`;
+  return (
+    <a href={pokemonUrl} className="text-decoration-none">
+      <Card className="align-items-center p-2">
+        {pokemon.mainImage && (
+          <Image
+            src={pokemon.mainImage}
+            width={80}
+            height={80}
+            roundedCircle
+            className="mb-2"
+          />
+        )}
+        <Card.Text>{pokemon.pokemonName}</Card.Text>
+      </Card>
+    </a>
+  );
+}


### PR DESCRIPTION
## Summary
- add Pokémon evolution card component
- display evolutions as centered flex cards on details page

## Testing
- `npm run build` *(fails: next not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c6cb1c82483228e180892a934d735