### PR TITLE
Add arrows between evolutions

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import 'bootstrap/dist/css/bootstrap.min.css';
 
+
 const geistSans = Geist({
   variable: "--font-geist-sans",
   subsets: ["latin"],
@@ -24,6 +25,12 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
+      <head>
+        <link
+          rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
+        />
+      </head>
       <body className={`${geistSans.variable} ${geistMono.variable}`}>
         {children}
       </body>

--- a/src/app/pokemon/[pokemon_id]/page.tsx
+++ b/src/app/pokemon/[pokemon_id]/page.tsx
@@ -2,12 +2,13 @@
 // Next.js by default would render this content on the server side where the application is hosted.
 'use client'
 import Pokemon from '@/model/pokemon';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, Fragment } from 'react';
 import { Row, Col, Container, Image, ProgressBar, Card } from 'react-bootstrap';
 import PokeNavBarNoSearchComp from '@/components/pokeNavBarNoSearchComp';
 import PokemonTypeBadgeComp from '@/components/pokemonTypeBadgeComp';
 import PokemonEvolutionCardComp from '@/components/pokemonEvolutionCardComp';
 import TYPE_COLORS from '@/utils/typeColors';
+import '../evolutionArrows.css';
 
 
 
@@ -116,16 +117,25 @@ export default function PokemonPage({ params }: Params) {
           <Row className="justify-content-center">
             <Col md="auto" className="text-center">
               <h4 className="mb-2">Evolution</h4>
-              <div className="d-flex justify-content-center flex-wrap gap-3">
-                {pokemon.evolutionFamily.map((name) => {
+              <div className="d-flex justify-content-center flex-wrap gap-3 align-items-center">
+                {pokemon.evolutionFamily.map((name, index) => {
                   const evo = allPokemons.find((p) => p.pokemonName === name);
 
-                  return evo ? (
+                  const card = evo ? (
                     <PokemonEvolutionCardComp key={name} pokemon={evo} />
                   ) : (
                     <Card key={name} className="align-items-center p-2">
                       <Card.Text>{name}</Card.Text>
                     </Card>
+                  );
+
+                  return (
+                    <Fragment key={name}>
+                      {card}
+                      {index < pokemon.evolutionFamily.length - 1 && (
+                        <i className="fa-solid fa-arrow-right evolution-arrow" />
+                      )}
+                    </Fragment>
                   );
                 })}
               </div>

--- a/src/app/pokemon/evolutionArrows.css
+++ b/src/app/pokemon/evolutionArrows.css
@@ -1,0 +1,6 @@
+.evolution-arrow {
+  margin: 0 8px;
+  font-size: 1.5rem;
+  color: var(--foreground);
+}
+


### PR DESCRIPTION
## Summary
- display arrows between evolution cards
- include Font Awesome stylesheet in layout
- provide CSS file to style arrows

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c793487ac832296ea82568b42f8f5